### PR TITLE
Support for pub global binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,7 @@
 ## 0.1.1+1
 
 - Fix formatting for README.md
+
+## 0.1.2
+
+- Add support for at_app when using the pub global binaries

--- a/README.md
+++ b/README.md
@@ -31,10 +31,22 @@ Activate the executable:
 flutter pub global activate at_app
 ```
 
+Make sure the pub cache bin is on your path:
+
+```
+Windows: %LOCALAPPDATA%/Pub/Cache/bin
+Mac/Linux: ~/.pub-cache/bin
+```
+
 Create a new @ platform app:
 
 ```sh
-flutter pub global run at_app create [...options] <output directory>
+at_app create [...options] <output directory>
+```
+
+Or for windows
+```sh
+at_app.bat create [...options] <output directory>
 ```
 
 #### Flags

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ flutter pub global run at_app create [...options] <output directory>
 | Flag          | Shorthand | Description                                             | Value                     |
 | ------------- | --------- | ------------------------------------------------------- | ------------------------- |
 | --namespace   | -n        | The @protocol app namespace to use for the application. | (defaults to "")          |
-| --root-domain | -r        | The @protocol root domain to use for the application.   | [prod (default), dev, ve] |
+| --root-domain | -r        | The @protocol root domain to use for the application.   | [prod (default), ve] |
 | --api-key     | -k        | The api key for at_onboarding_flutter.                  | (defaults to "")          |
 
 ### Library

--- a/bin/src/commands/create.dart
+++ b/bin/src/commands/create.dart
@@ -57,9 +57,9 @@ class AtCreateCommand extends CreateBase {
       'root-domain',
       abbr: 'r',
       help: 'The @protocol root domain to use for the application.',
-      allowed: ['prod', 'dev', 've'],
+      allowed: ['prod', 've'],
       defaultsTo: 'prod',
-      valueHelp: 'prod | dev | ve',
+      valueHelp: 'prod | ve',
     );
     argParser.addOption(
       'api-key',
@@ -217,8 +217,6 @@ Your $projectType code is in $relativeAppMain.
 
   String _getRootDomain(String flag) {
     switch (flag) {
-      case 'dev':
-        return 'root.atsign.wtf';
       case 've':
         return 'vip.ve.atsign.zone';
       case 'prod':

--- a/bin/src/file/template_manager.dart
+++ b/bin/src/file/template_manager.dart
@@ -37,7 +37,6 @@ class TemplateManager extends FileManager {
         setSourceFromPubCache();
       }
       var sourceLines = await source.readAsLines();
-      print('Using main.dart from: ${source.path}');
       await write(sourceLines);
     } catch (error) {
       print(error.toString());

--- a/bin/src/file/template_manager.dart
+++ b/bin/src/file/template_manager.dart
@@ -2,26 +2,68 @@
 
 import 'dart:io';
 
+import 'package:version/version.dart';
+
 import 'file_manager.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
 
 class TemplateManager extends FileManager {
   File source;
+  String hostedPubCachePath;
+  String packageVersion;
 
   TemplateManager(Directory projectDir, String filename, String source)
       : source = FileManager.fileFromPath(source),
-        super(projectDir, filename);
+        super(projectDir, filename) {
+    var platform = LocalPlatform();
+    var pubCachePath = platform.environment['PUB_CACHE'];
+    if (pubCachePath == null) {
+      if (platform.isWindows) {
+        pubCachePath = '${platform.environment['LOCALAPPDATA']}\\Pub\\Cache';
+      } else {
+        pubCachePath = '${platform.environment['HOME']}/.pub-cache';
+      }
+    }
+    hostedPubCachePath = '$pubCachePath/hosted/pub.dartlang.org';
+  }
 
   Future<bool> copyTemplate() async {
     try {
       while (existsSync == false) {
         sleep(Duration(milliseconds: 500));
       }
+      if (!source.existsSync()) {
+        setSourceFromPubCache();
+      }
       var sourceLines = await source.readAsLines();
+      print('Using main.dart from: ${source.path}');
       await write(sourceLines);
     } catch (error) {
       print(error.toString());
       return false;
     }
     return true;
+  }
+
+  void setSourceFromPubCache() {
+    List<Version> entries = Directory(hostedPubCachePath)
+        .listSync(recursive: false)
+        .map((element) => globals.fs.path.split(element.path).last)
+        .where((element) {
+          print(element);
+          return element.startsWith('at_app');
+        })
+        .map((element) => Version.parse(element.replaceFirst('at_app-', '')))
+        .toList();
+
+    Version version;
+    entries.forEach((element) {
+      if (version == null || element > version) {
+        version = element;
+      }
+    });
+    source = FileManager.fileFromPath(
+        '$hostedPubCachePath/at_app-${version.toString()}/lib/templates/main.dart');
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -784,6 +784,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  version:
+    dependency: "direct main"
+    description:
+      name: version
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   flutter_tools:
     sdk: flutter
   path_provider: ^2.0.2
+  version: ^2.0.0
 
 dev_dependencies:
   pedantic: ^1.10.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_app
 description: A command line tool to help developers build an @ platform application.
-version: 0.1.1+1
+version: 0.1.2
 repository: https://github.com/atsign-foundation/at_app_cli
 homepage: https://atsign.dev/
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Removed dev environment from the flags - as requested earlier this morning.

Added support for pub global binaries.

**- How I did it**

Added a fallback to pull the template directly from the pub cache, if the file is not found the first time.
- This fallback should be guaranteed when installed via pub global activate, since the package is also added to the pub cache when the binary is created using this command.

**- How to verify it**

Test the global command by activating via git:
```
flutter pub global activate -s git https://github.com/XavierChanth/at_app_cli.git --overwrite
```

Make sure the pub cache bin is on the path:
```
Windows: %LOCALAPPDATA%/Pub/Cache/bin
Mac/Linux: ~/.pub-cache/bin
```

Then test the command:
```
at_app create <test-folder>
```

Windows will compile to at_app.bat:
```
at_app.bat create <test-folder>
```

**- Description for the changelog**
Add support for pub global binaries. 