### PR TITLE
Use rsdk templates and bug fix for pub_cache location issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0-rc+3
+
+- at_app now uses at_app_flutter version 1.0.0-rc
+
 ## 1.1.0-rc+2
 
 - at_app now uses .dart_tool/package_config.json to locate the template files contained in at_app_flutter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- Publish release candidate 1.1.0-rc+3
+
 ## 1.1.0-rc+3
 
 - at_app now uses at_app_flutter version 1.0.0-rc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0-rc+2
+
+- at_app now uses .dart_tool/package_config.json to locate the template files contained in at_app_flutter
+
 ## 1.1.0-rc+1
 
 - Catch errors caused by pub adding to a project that already has the dependency

--- a/lib/src/command_runner.dart
+++ b/lib/src/command_runner.dart
@@ -3,7 +3,7 @@ import 'package:args/command_runner.dart';
 import 'package:logger/logger.dart';
 
 import 'commands/command_status.dart';
-import 'commands/index.dart';
+import 'commands/create.dart';
 import 'util/printer.dart';
 import 'version.dart';
 

--- a/lib/src/commands/create.dart
+++ b/lib/src/commands/create.dart
@@ -135,9 +135,10 @@ Happy coding!
         directory: projectDir,
       );
     } catch (e) {
-      _logger
-          .w('Unable to run "pub add $templatePackageName:$templatePackageVersion"');
-      _logger.i('This may not be an error, the package may already be added to the project.');
+      _logger.w(
+          'Unable to run "pub add $templatePackageName:$templatePackageVersion"');
+      _logger.i(
+          'This may not be an error, the package may already be added to the project.');
     }
 
     if (boolArg('pub')!) {

--- a/lib/src/commands/create_base.dart
+++ b/lib/src/commands/create_base.dart
@@ -116,10 +116,12 @@ abstract class CreateBase extends Command<CommandStatus> {
     File mainFile = File('${projectDir.absolute.path}/lib/main.dart');
     final bool exists = mainFile.existsSync();
 
-    if (!validatePackageName(
-        projectName ?? path.basename(projectDir.absolute.path))) {
+    var packageName =
+        projectName ?? path.basename(path.normalize(projectDir.absolute.path));
+
+    if (!validatePackageName(packageName)) {
       throw FormatException(
-          '"$projectName" is not a valid Dart package name.\n\n'
+          '"$packageName" is not a valid Dart package name.\n\n'
           'See https://dart.dev/tools/pub/pubspec#name for more information.');
     }
 

--- a/lib/src/commands/index.dart
+++ b/lib/src/commands/index.dart
@@ -1,1 +1,0 @@
-export 'create.dart';

--- a/lib/src/util/cache_package.dart
+++ b/lib/src/util/cache_package.dart
@@ -1,0 +1,26 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+
+class CachePackage {
+  String packageName;
+  Directory projectDir;
+  late Map<String, dynamic> packageInfo;
+
+  CachePackage(this.packageName, this.projectDir) {
+    File packageConfigFile = File(
+      path.joinAll([
+        projectDir.absolute.path,
+        '.dart_tool',
+        'package_config.json',
+      ]),
+    );
+
+    packageInfo = jsonDecode(packageConfigFile.readAsStringSync())['packages']
+        .firstWhere((package) => package['name'] as String == packageName);
+  }
+
+  Uri get rootUri => Uri.parse(packageInfo['rootUri']!);
+  String get baseUrl => rootUri.toFilePath();
+}

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,7 +1,7 @@
 import 'package:pub_semver/pub_semver.dart';
 
 /// Current version of this package
-final packageVersion = Version(1, 1, 0, pre: 'rc', build: '1');
+final packageVersion = Version(1, 1, 0, pre: 'rc', build: '2');
 
 /// Name of the package containing the templates
 final templatePackageName = 'at_app_flutter';

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,10 +1,10 @@
 import 'package:pub_semver/pub_semver.dart';
 
 /// Current version of this package
-final packageVersion = Version(1, 1, 0, pre: 'rc', build: '2');
+final packageVersion = Version(1, 1, 0, pre: 'rc', build: '3');
 
 /// Name of the package containing the templates
 final templatePackageName = 'at_app_flutter';
 
 /// Version of the package to use for templates
-final templatePackageVersion = Version(0, 2, 0, pre: 'rc');
+final templatePackageVersion = Version(1, 0, 0, pre: 'rc');

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,10 +1,10 @@
 import 'package:pub_semver/pub_semver.dart';
 
 /// Current version of this package
-final packageVersion = Version(1, 1, 0, pre: 'rc', build: '3');
+final packageVersion = Version(1, 1, 0);
 
 /// Name of the package containing the templates
 final templatePackageName = 'at_app_flutter';
 
 /// Version of the package to use for templates
-final templatePackageVersion = Version(1, 0, 0, pre: 'rc');
+final templatePackageVersion = Version(1, 1, 0);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_app
 description: A command line tool to help developers build an @ platform application.
-version: 1.1.0-rc+2
+version: 1.1.0-rc+3
 repository: https://github.com/atsign-foundation/at_app
 homepage: https://atsign.dev/
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_app
 description: A command line tool to help developers build an @ platform application.
-version: 1.1.0-rc+1
+version: 1.1.0-rc+2
 repository: https://github.com/atsign-foundation/at_app
 homepage: https://atsign.dev/
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_app
 description: A command line tool to help developers build an @ platform application.
-version: 1.1.0-rc+3
+version: 1.1.0
 repository: https://github.com/atsign-foundation/at_app
 homepage: https://atsign.dev/
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

This is 1/2 PRs for at_app, the other being [here](https://github.com/atsign-foundation/at_widgets/pull/204)

closes #15 
closes #17 

**- What I did**

- Used the .dart_tool/package_config.json file to get the location of at_app_flutter on the user's machine
- Updated the [at_app_flutter version](https://github.com/atsign-foundation/at_widgets/pull/204) to use the new rsdk release

**- How I did it**

- Local changes

**- How to verify it**
You may test using release candidate 1.1.0-rc+3, the only difference is version numbers and changelogs.
```
flutter pub global activate at_app 1.1.0-rc+3
```

**- Description for the changelog**
Use rsdk templates and bug fix for pub_cache location issues
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->