### PR TITLE
Update create.dart to allow `dart run at_app/bin/at_app.dart create —list-demos`  to run without error

### DIFF
--- a/at_app/lib/src/commands/create.dart
+++ b/at_app/lib/src/commands/create.dart
@@ -106,7 +106,7 @@ class CreateCommand extends CreateBase {
       return _listOptions(sampleNames, 'SAMPLE');
     }
 
-    if (argResults!.wasParsed('list-demo')) {
+    if (argResults!.wasParsed('list-demos')) {
       return _listOptions(demoNames, 'DEMO');
     }
 


### PR DESCRIPTION
Missing 's' breaks the command

```
dart run at_app/bin/at_app.dart create —list-demos
```

Tested and this fixes that issue


-->

**- What I did**
Followed the documented instructions to test a new demo

**- How I did it**
dart run at_app/bin/at_app.dart create —list-demos
```
PS C:\Users\colin\GitHub\@foundation\at_app> dart run at_app/bin/at_app.dart create --list-demos
Unhandled exception:
Invalid argument(s): Could not find an option named "list-demo".
#0      ArgResults.wasParsed (package:args/src/arg_results.dart:95:7)
#1      CreateCommand.run (package:at_app/src/commands/create.dart:109:21)
#2      CommandRunner.runCommand (package:args/command_runner.dart:209:27)
#3      AtCommandRunner.runCommand (package:at_app/src/command_runner.dart:49:18)
#4      AtCommandRunner.run (package:at_app/src/command_runner.dart:31:20)
#5      main (file:///C:/Users/colin/GitHub/@foundation/at_app/at_app/bin/at_app.dart:4:27)
#6      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:295:32)
#7      _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:192:12)
PS C:\Users\colin\GitHub\@foundation\at_app>
```
Fails

**- How to verify it**

After bug fix
```
PS C:\Users\colin\GitHub\@foundation\at_app> dart run at_app/bin/at_app.dart create --list-demos

DEMO     | DESCRIPTION
---------|------------------------------------------------
snackbar | Send and receive end to end encrypted snackbars
PS C:\Users\colin\GitHub\@foundation\at_app>

```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->