### PR TITLE
Fix behavior of packages list command

### DIFF
--- a/at_app/lib/src/commands/package_commands/list.dart
+++ b/at_app/lib/src/commands/package_commands/list.dart
@@ -19,9 +19,9 @@ The packages are grouped into three categories: flutter, utility, core.''';
   final Logger _logger = LoggerService().logger;
 
   ListCommand() {
-    argParser.addFlag('flutter', abbr: 'f');
-    argParser.addFlag('util', abbr: 'u');
-    argParser.addFlag('core', abbr: 'c');
+    argParser.addFlag('flutter', abbr: 'f', negatable: false);
+    argParser.addFlag('util', abbr: 'u', negatable: false);
+    argParser.addFlag('core', abbr: 'c', negatable: false);
     argParser.addFlag('all', abbr: 'a', negatable: false);
   }
 

--- a/at_app/lib/src/commands/package_commands/list.dart
+++ b/at_app/lib/src/commands/package_commands/list.dart
@@ -19,7 +19,7 @@ The packages are grouped into three categories: flutter, utility, core.''';
   final Logger _logger = LoggerService().logger;
 
   ListCommand() {
-    argParser.addFlag('flutter', abbr: 'f', defaultsTo: false);
+    argParser.addFlag('flutter', abbr: 'f');
     argParser.addFlag('util', abbr: 'u');
     argParser.addFlag('core', abbr: 'c');
     argParser.addFlag('all', abbr: 'a', negatable: false);

--- a/at_app/lib/src/commands/package_commands/list.dart
+++ b/at_app/lib/src/commands/package_commands/list.dart
@@ -19,7 +19,7 @@ The packages are grouped into three categories: flutter, utility, core.''';
   final Logger _logger = LoggerService().logger;
 
   ListCommand() {
-    argParser.addFlag('flutter', abbr: 'f', defaultsTo: true);
+    argParser.addFlag('flutter', abbr: 'f', defaultsTo: false);
     argParser.addFlag('util', abbr: 'u');
     argParser.addFlag('core', abbr: 'c');
     argParser.addFlag('all', abbr: 'a', negatable: false);
@@ -41,12 +41,7 @@ The packages are grouped into three categories: flutter, utility, core.''';
       }
     }
 
-    /// Nothing to print
-    if (flagCount == 0) {
-      throw const FormatException(
-        'At least one group of packages must be specified',
-      );
-    }
+    final bool justFlutter = flagCount == 0;
 
     List<List<String>> display = [
       ['PACKAGE', 'DESCRIPTION']
@@ -54,7 +49,7 @@ The packages are grouped into three categories: flutter, utility, core.''';
     List<int> rowDividers = [1];
 
     /// Flutter Packages
-    if (showAll || (argResults?['flutter'] ?? false)) {
+    if (showAll || justFlutter || (argResults?['flutter'] ?? false)) {
       if (display.length > 1) rowDividers.add(display.length);
       display.addAll([
         if (flagCount > 1) ['FLUTTER PACKAGES'],
@@ -87,8 +82,7 @@ The packages are grouped into three categories: flutter, utility, core.''';
       rowDividers: rowDividers,
     ));
 
-    final String packageCount =
-        '''\nShowing $flagCount/${flags.length} package groups.
+    final String packageCount = '''\nShowing $flagCount/${flags.length} package groups.
 
 To show available groups:
 at_app${Platform.isWindows ? '.bat' : ''} packages list --help''';


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

While documenting the `packages list` command, I noticed the behavior to be odd by convention.

By default flutter packages are shown, so `at_app packages list` yields only Flutter as expected.

However it is strange that `at_app packages list -u` would yield both Flutter and utility packages.

I changed it so that `at_app packages list -u` and `at_app packages list -c` don't yield the flutter packages.

**- How I did it**

Local changes.

**- How to verify it**

Try it out, however the changes are quite trivial.

**- Description for the changelog**
Fix behavior of packages list command.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->