### PR TITLE
fix: workflow permissions

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -2,34 +2,21 @@ name: CI
 
 on:
   push:
-  pull_request_target:
+    branches:
+      - trunk
+  pull_request:
+    branches:
+      - trunk
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: write # Enable temporary branch creation for testing
-
-    env:
-      is_pr: ${{ github.event.pull_request && github.event.pull_request.head.repo.full_name != github.repository }}
-      branch: ${{ github.event.pull_request && github.event.pull_request.head.repo.full_name != github.repository && format('build_action-{0}-{1}', github.run_id, github.run_attempt) || github.head_ref }}
-
     outputs:
-      commit_ref: ${{ env.is_pr && format('build_action-{0}-{1}', github.run_id, github.run_attempt) || steps.commit_id.outputs.changes_detected && steps.commit_id.outputs.commit_hash || github.sha }}
+      commit_ref: ${{ steps.commit_id.outputs.changes_detected && steps.commit_id.outputs.commit_hash || github.ref }}
 
     steps:
-      - uses: peterjgrainger/action-create-branch@v2.2.0
-        if: ${{ env.is_pr }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          branch: ${{ env.branch }}
-          sha: ${{ github.event.pull_request.head.sha }}
-
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ env.branch }}
 
       - uses: subosito/flutter-action@v2
         with:
@@ -45,12 +32,6 @@ jobs:
         id: commit_id
         with:
           commit_message: Commit automated build
-          # Create a temporary branch to run tests on if it is a PR from a fork
-          create_branch: ${{ env.is_pr }}
-          # Label the branch by run_id and run_attempt if it is a PR from a fork
-          # OR use the head branch if it is not
-          branch: ${{ env.branch }}
-          repository: ${{ github.repo }}
 
       - run: echo ${{ steps.commit_id.outputs.commit_hash }}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Workflow failed due to stricter permission on trunk
- Now using a similar technique to at_client_sdk and at_server (i.e. ci will fail when pr is from a fork to trunk)

**- How I did it**

Local changes

**- How to verify it**

See build workflow

**- Description for the changelog**
fix: workflow permissions
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->