### PR TITLE
chore(at_app_flutter): expand version constraint of at_onboarding_flutter to '>=4.0.0 <6.0.0'.

### DIFF
--- a/packages/at_app_flutter/CHANGELOG.md
+++ b/packages/at_app_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.1
+
+- **Chore**: Updated dependency at_onboarding_flutter version to support major versions 4.x.x and 5.x.x.
+
 ## 5.0.0+2
 
   - **Chore**: Updated CI badge to refer to the new CI process.

--- a/packages/at_app_flutter/pubspec.yaml
+++ b/packages/at_app_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_app_flutter
 description: A library that help developers build flutter applications on the @platform.
-version: 5.0.0+2
+version: 5.0.1
 repository: https://github.com/atsign-foundation/at_app/tree/trunk/packages/at_app_flutter/
 homepage: https://atsign.dev/
 
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  at_onboarding_flutter: ^4.0.0
+  at_onboarding_flutter: '>=4.0.0 <6.0.0'
   at_utils: ^3.0.5
   flutter_dotenv: ^5.0.2
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Expanded the version constraint of at_onboarding_flutter to support 4.x.x and 5.x.x in at_app_flutter's dependencies.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore(at_app_flutter): expand version constraint of at_onboarding_flutter to '>=4.0.0 <6.0.0'.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->