### PR TITLE
fix: logger colors

### DIFF
--- a/packages/at_app/CHANGELOG.md
+++ b/packages/at_app/CHANGELOG.md
@@ -1,6 +1,12 @@
+## 4.5.0
+
+- **Chore**: Use `lints: >=1.0.0 <3.0.0` in dev_dependencies.
+- **Fix**: Logger color accessibility issues on light mode terminals.
+  - Added `chalk: 1.2.0` as a dependency.
+
 ## 4.4.0
 
-  - **Chore**: Use `at_app_create ^0.2.0`.
+  - **Chore**: Use `at_app_create: ^0.2.0`.
   - **Chore**: Updated dependencies of all templates to latest.
   - **Fix**(Windows): Explicitly added `biometric_storage: ^4.1.3` as a dependency to all templates.
 
@@ -20,7 +26,7 @@
 
 ## 4.2.3
 
-  - **Chore**: Use `at_app_create ^0.1.1`.
+  - **Chore**: Use `at_app_create: ^0.1.1`.
 
 ## 4.2.2+1
 
@@ -61,18 +67,18 @@
 
 ## 3.0.0
 
-- **BREAKING CHANGE**: Depends on at_app_flutter 3.0.0
-- **Chore**: Updated the android build config for flutter_config (introduced in at_app_flutter 3.0.0)
+- **BREAKING CHANGE**: Depends on `at_app_flutter: ^3.0.0`
+- **Chore**: Updated the android build config for flutter_config (introduced in `at_app_flutter ^3.0.0`)
 - **Chore**: Updated the default compileSdkVersion to 31 for android apps
 - **Chore**: Performance optimizations to file management
 
 ## 2.0.0
 
-- **BREAKING CHANGE**: Depends on at_app_flutter 2.0.0
+- **BREAKING CHANGE**: Depends on `at_app_flutter: ^2.0.0`
 
 ## 1.1.1
 
-- **Chore**: Depends on at_app_flutter 1.1.1
+- **Chore**: Depends on `at_app_flutter: ^1.1.1`
 
 ## 1.1.0
 

--- a/packages/at_app/lib/src/version.dart
+++ b/packages/at_app/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '4.4.0';
+const packageVersion = '4.5.0';

--- a/packages/at_app/pubspec.yaml
+++ b/packages/at_app/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   mason: 0.1.0-dev.8
   at_app_create: ^0.2.0
   meta: ^1.7.0
+  chalk: ^1.2.0
 
 dev_dependencies:
   flutter_lints: ">=1.0.4 <3.0.0"

--- a/packages/at_app/pubspec.yaml
+++ b/packages/at_app/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_app
 description: A command line tool to help developers build an @ platform application.
-version: 4.4.0
+version: 4.5.0
 repository: https://github.com/atsign-foundation/at_app/tree/trunk/packages/at_app/
 homepage: https://atsign.dev/
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

closes #171 

**- What I did**

Fixed accessibility issues with at_apps stdout logger in light mode:
-  Replace `logger`'s AnsiColor class with `chalk`'s functions

**- How I did it**

Local changes.

**- How to verify it**
Before:
![CleanShot 2022-10-05 at 18 45 31](https://user-images.githubusercontent.com/33691921/194177461-07e30857-7956-4e54-b2f9-6523972b4a45.png)

After:
![CleanShot 2022-10-05 at 18 44 22](https://user-images.githubusercontent.com/33691921/194177293-ed7e3ed5-ed34-4324-a34d-537374a2635f.png)

**- Description for the changelog**
fix: logger colors
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->