### PR TITLE
build(deps): Bump ossf/scorecard-action to v2.1.2

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@15c10fcf1cf912bd22260bfec67569a359ab87da # v2.1.1
+        uses: ossf/scorecard-action@e38b1902ae4f44df626f11ba0734b14fb91f8f86 # v2.1.2
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Fixes #232 

**- What I did**

Bump scorecard action to v2.1.2

**- How to verify it**

Merge to trunk should result in a successful scorecard action run

**- Description for the changelog**

build(deps): Bump ossf/scorecard-action to v2.1.2