### PR TITLE
fix: warn developer when AtEnv fails to load

### DIFF
--- a/packages/at_app_flutter/CHANGELOG.md
+++ b/packages/at_app_flutter/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 5.1.0
 
-- **Fix**: `flutter_dotenv`'s Errors were previously caught and suppressed by AtEnv failing to warn the user.
+- **Fix**: `flutter_dotenv`'s Errors were previously caught and suppressed by AtEnv failing to warn the developer.
   - AtEnv now warns the user that the `.env` file failed to load, and the reason why.
 
 ## 5.0.1

--- a/packages/at_app_flutter/CHANGELOG.md
+++ b/packages/at_app_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.1.0
+
+- **Fix**: `flutter_dotenv`'s Errors were previously caught and suppressed by AtEnv failing to warn the user.
+  - AtEnv now warns the user that the `.env` file failed to load, and the reason why.
+
 ## 5.0.1
 - **Chore**: Updated at_onboarding_flutter dependency constraint to support major versions 4 and 5.
 

--- a/packages/at_app_flutter/lib/src/at_env.dart
+++ b/packages/at_app_flutter/lib/src/at_env.dart
@@ -5,8 +5,8 @@ import 'package:flutter_dotenv/flutter_dotenv.dart' show dotenv, DotEnv;
 import 'package:flutter_dotenv/src/errors.dart' show EmptyEnvFileError, FileNotFoundError, NotInitializedError;
 import 'package:meta/meta.dart';
 
-const String apiKeyWarning = '''\x1B[33mWARNING: API_KEY is not set in .env file
-Make sure to set the API_KEY before releasing to production.\x1B[0m''';
+const String apiKeyWarning =
+    'WARNING: API_KEY is not set in .env file\nMake sure to set the API_KEY before releasing to production.';
 
 AtSignLogger _logger = AtSignLogger('AtEnv');
 
@@ -55,7 +55,7 @@ class AtEnv {
   /// otherwise the free @sign generator will not work.
   static RootEnvironment get rootEnvironment {
     if (appApiKey == null) {
-      print(apiKeyWarning);
+      _logger.warning(apiKeyWarning);
       return RootEnvironment.Staging;
     }
     return RootEnvironment.Production;

--- a/packages/at_app_flutter/lib/src/at_env.dart
+++ b/packages/at_app_flutter/lib/src/at_env.dart
@@ -18,8 +18,15 @@ class AtEnv {
   /// Load the environment variables from the .env file.
   ///
   /// Calls [load()] from flutter_dotenv package.
-  static Future<void> load({Map<String, String> mergeWith = const <String, String>{}}) =>
-      dotenv.load(mergeWith: mergeWith);
+  static Future<void> load({Map<String, String> mergeWith = const <String, String>{}}) async {
+    try {
+      await dotenv.load(mergeWith: mergeWith);
+    } on FileNotFoundError {
+      _logger.warning('The .env file was not found, using fallback values instead.');
+    } on EmptyEnvFileError {
+      _logger.warning('The .env file is empty, using fallback values instead.');
+    }
+  }
 
   /// Returns the value for ['ROOT_DOMAIN'] from the .env file.
   ///
@@ -73,12 +80,6 @@ class AtEnv {
       return result;
     } on NotInitializedError {
       _logger.warning('The .env file has not been loaded, using fallback values instead.');
-      return fallback;
-    } on FileNotFoundError {
-      _logger.warning('The .env file was not found, using fallback values instead.');
-      return fallback;
-    } on EmptyEnvFileError {
-      _logger.warning('The .env file is empty, using fallback values instead.');
       return fallback;
     } catch (_) {
       rethrow;

--- a/packages/at_app_flutter/pubspec.yaml
+++ b/packages/at_app_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_app_flutter
 description: A library that help developers build flutter applications on the atPlatform.
-version: 5.0.1
+version: 5.1.0
 repository: https://github.com/atsign-foundation/at_app/tree/trunk/packages/at_app_flutter/
 homepage: https://docs.atsign.com/
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed a hidden side-effect of trying to make things a bit too easy for developers.

I suppressed all errors thrown by AtEnv when the .env file is missing, empty, or not yet loaded. This caused an issue that would cause the fallback value to be permanently loaded if a value was retrieved from AtEnv before AtEnv.load was called.

**- How I did it**

Logged a warning for all three Error cases stating what error occurred, and that the fallback value was being used.

**- How to verify it**


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->