### PR TITLE
chore: use dependabot at the root of the repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,35 +8,6 @@ updates:
       interval: "daily"
   # Maintain dependencies for packages
   - package-ecosystem: "pub"
-    directory: "/packages/at_app"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "pub"
-    directory: "/packages/at_app_bundler"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "pub"
-    directory: "/packages/at_app_create"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "pub"
-    directory: "/packages/at_app_flutter"
-    schedule:
-      interval: "daily"
-  # Maintain dependencies for templates
-  - package-ecosystem: "pub"
-    directory: "/templates/demos/chit_chat"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "pub"
-    directory: "/templates/demos/snackbar"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "pub"
-    directory: "/templates/demos/snackbar_sender"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "pub"
-    directory: "/templates/templates/app"
+    directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Dependabot config was set separately for each package, template, etc... which caused there to be multiple PRs to make the same updates to each package.

This should hopefully allow each of the updates to happen simultaneously since the dependabot for at_app should be the same as at_app_create, etc.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore: use dependabot at the root of the repo
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->